### PR TITLE
feat: add converter for regexp nodes

### DIFF
--- a/packages/nfa/lib/regexp.js
+++ b/packages/nfa/lib/regexp.js
@@ -19,6 +19,66 @@ export const ops = {
  */
 
 /**
+ * @template VALUE
+ * @param {ParseTree<VALUE>} left
+ * @param {ParseTree<VALUE>} right
+ * @returns {ParseTree<VALUE>}
+ */
+export function choice(left, right) {
+  const node = {
+    parent: undefined,
+    op: ops.choice,
+    value: undefined,
+    node: undefined,
+    nodes: undefined,
+    left,
+    right,
+  };
+  left.parent = node;
+  right.parent = node;
+  return node;
+}
+
+/**
+ * @template U, V
+ * @param {ParseTree<U>} tree
+ * @param {(value: U | undefined) => V} mapper
+ * @returns {ParseTree<V>}
+ */
+export function convertNode(tree, mapper) {
+  const value = mapper(tree.value);
+  const node = tree.node ? convertNode(tree.node, mapper) : undefined;
+  const nodes = tree.nodes
+    ? tree.nodes.map((node) => convertNode(node, mapper))
+    : undefined;
+  const left = tree.left ? convertNode(tree.left, mapper) : undefined;
+  const right = tree.right ? convertNode(tree.right, mapper) : undefined;
+
+  const result = {
+    parent: undefined,
+    op: tree.op,
+    value,
+    node,
+    nodes,
+    left,
+    right,
+  };
+  if (node) {
+    node.parent = result;
+  }
+  if (nodes) {
+    nodes.forEach((node) => (node.parent = result));
+  }
+  if (left) {
+    left.parent = result;
+  }
+  if (right) {
+    right.parent = result;
+  }
+  return result;
+}
+
+/**
  * @param {string} input
  * @returns {ParseTree<string>}
  */

--- a/packages/nfa/lib/regexp.test.js
+++ b/packages/nfa/lib/regexp.test.js
@@ -1,4 +1,4 @@
-import { parse, ops } from "./regexp.js";
+import { parse, ops, convertNode } from "./regexp.js";
 
 /**
  * @template T
@@ -6,8 +6,9 @@ import { parse, ops } from "./regexp.js";
  */
 
 /**
- * @param {Partial<ParseTree<string>>} template
- * @returns {ParseTree<string>}
+ * @template T
+ * @param {Partial<ParseTree<T>>} template
+ * @returns {ParseTree<T>}
  */
 const node = (template) => {
   const parent = {
@@ -35,7 +36,7 @@ const node = (template) => {
   return parent;
 };
 
-describe("regexp", () => {
+describe("parse", () => {
   it("should parse a sequence of characters", () => {
     expect(parse("abc")).toEqual(
       node({
@@ -207,6 +208,156 @@ describe("regexp", () => {
           node({
             op: ops.match,
             value: "c",
+          }),
+        ],
+      })
+    );
+  });
+});
+
+describe("convertNode", () => {
+  it("should convert an any node", () => {
+    expect(
+      convertNode(
+        node({
+          op: ops.any,
+          value: undefined,
+        }),
+        (value) => ({
+          name: "name",
+          value: value,
+        })
+      )
+    ).toEqual(
+      node({
+        op: ops.any,
+        value: {
+          name: "name",
+          value: undefined,
+        },
+      })
+    );
+  });
+
+  it("should convert a match node", () => {
+    expect(
+      convertNode(
+        node({
+          op: ops.match,
+          value: "a",
+        }),
+        (value) => ({
+          name: "name",
+          value: value,
+        })
+      )
+    ).toEqual(
+      node({
+        op: ops.match,
+        value: {
+          name: "name",
+          value: "a",
+        },
+      })
+    );
+  });
+
+  it("should convert a choice node", () => {
+    expect(
+      convertNode(
+        node({
+          op: ops.choice,
+          left: node({}),
+          right: node({}),
+        }),
+        (value) => ({
+          name: "name",
+          value: value,
+        })
+      )
+    ).toEqual(
+      node({
+        op: ops.choice,
+        value: {
+          name: "name",
+          value: undefined,
+        },
+        left: node({
+          value: {
+            name: "name",
+            value: undefined,
+          },
+        }),
+        right: node({
+          value: {
+            name: "name",
+            value: undefined,
+          },
+        }),
+      })
+    );
+  });
+
+  it("should convert an optional node", () => {
+    expect(
+      convertNode(
+        node({
+          op: ops.optional,
+          node: node({}),
+        }),
+        (value) => ({
+          name: "name",
+          value: value,
+        })
+      )
+    ).toEqual(
+      node({
+        op: ops.optional,
+        value: {
+          name: "name",
+          value: undefined,
+        },
+        node: node({
+          value: {
+            name: "name",
+            value: undefined,
+          },
+        }),
+      })
+    );
+  });
+
+  it("should convert an sequence node", () => {
+    expect(
+      convertNode(
+        node({
+          op: ops.sequence,
+          nodes: [node({}), node({})],
+        }),
+        (value) => ({
+          name: "name",
+          value: value,
+        })
+      )
+    ).toEqual(
+      node({
+        op: ops.sequence,
+        value: {
+          name: "name",
+          value: undefined,
+        },
+        nodes: [
+          node({
+            value: {
+              name: "name",
+              value: undefined,
+            },
+          }),
+          node({
+            value: {
+              name: "name",
+              value: undefined,
+            },
           }),
         ],
       })


### PR DESCRIPTION
This allows to augment extra data per regexp parse node.
This could be used to tag nodes per expression and combine
multiple expression into one while maintaining the source location.
