### PR TITLE
feat: optimize dfa result matching

### DIFF
--- a/packages/dfa/lib/dfa.js
+++ b/packages/dfa/lib/dfa.js
@@ -124,7 +124,9 @@ export class DFA {
     const error = errorState ?? -1;
 
     const code = `'use strict';
-      const table = new Uint8Array(${columns * d.states.length}).fill(${error});
+      const table = new Uint16Array(${
+        columns * d.states.length
+      }).fill(${error});
 
       ${transitions
         .flatMap(([from, transition]) =>
@@ -140,7 +142,7 @@ export class DFA {
         for (let i = 0, l = input.length; i < l; i++) {
           state = table[state + input[i]];
         }
-        return ${JSON.stringify(finals)}.indexOf(state) > -1;
+        return ${finals.map((final) => `${final} === state`).join(" || ")};
       };
     `;
 

--- a/packages/lexer/lib/lexer.js
+++ b/packages/lexer/lib/lexer.js
@@ -224,7 +224,9 @@ export function lexer(grammar, options) {
       let success = false;
       let n = i;
       while (!success && n > 0) {
-        success = success || finals.indexOf(visited[n]) > -1;
+        success = success || ${finals
+          .map((final) => `${final} === visited[n]`)
+          .join(" || ")};
         n--;
       }
       n = n + 1;


### PR DESCRIPTION
By unrolling the result state matching against possible final states we
do save a lot of cpu cycles compared to the native call.

This might turn around if the number of result states gets too big.
