### PR TITLE
test: add tests for empty expressions

### DIFF
--- a/packages/nfa/lib/nfa.test.js
+++ b/packages/nfa/lib/nfa.test.js
@@ -177,6 +177,16 @@ describe("NFA", () => {
 
       expect(result).toBe(true);
     });
+
+    it("should convert a choice with empty branch regexp into a NFA", async () => {
+      const nfa = NFA.fromRegExp("a|");
+
+      const match = nfa.test(["a"]);
+      expect(match).toBe(true);
+
+      const empty = nfa.test([]);
+      expect(empty).toBe(true);
+    });
   });
 
   it("should create a NFA with non string states and symbols", () => {

--- a/packages/nfa/lib/regexp.test.js
+++ b/packages/nfa/lib/regexp.test.js
@@ -128,6 +128,36 @@ describe("parse", () => {
     );
   });
 
+  it("should parse a choice expression with empty branch", () => {
+    expect(parse("aa|")).toEqual(
+      node({
+        op: ops.sequence,
+        nodes: [
+          node({
+            op: ops.choice,
+            left: node({
+              op: ops.sequence,
+              nodes: [
+                node({
+                  op: ops.match,
+                  value: "a",
+                }),
+                node({
+                  op: ops.match,
+                  value: "a",
+                }),
+              ],
+            }),
+            right: node({
+              op: ops.sequence,
+              nodes: [],
+            }),
+          }),
+        ],
+      })
+    );
+  });
+
   it("should parse a sub-expression", () => {
     expect(parse("(ab)")).toEqual(
       node({


### PR DESCRIPTION
This allows to express regular expressions with optional elements (only
epsilon transitions).
