### PR TITLE
feat: allow regexp to match escape sequences

### DIFF
--- a/packages/nfa/lib/regexp.js
+++ b/packages/nfa/lib/regexp.js
@@ -118,6 +118,21 @@ function seq(input) {
   return [i, node];
 }
 
+/** @type {[string, string][]} */
+const escapedCharacters = [
+  [".", "."],
+  ["(", "("],
+  [")", ")"],
+  ["|", "|"],
+  ["*", "*"],
+  ["\\", "\\"],
+  ["n", "\n"],
+  ["r", "\r"],
+  ["t", "\t"],
+  ["b", "\b"],
+  ["f", "\f"],
+];
+
 /**
  * @param {ParseTree<string>[]} stack
  * @param {string} input
@@ -125,11 +140,17 @@ function seq(input) {
  */
 function next(stack, input) {
   const isEscapeSequence = input[0] === "\\";
-  if (isEscapeSequence && [".", "(", ")", "|", "*", "\\"].includes(input[1])) {
+  if (
+    isEscapeSequence &&
+    escapedCharacters.map((c) => c[0]).includes(input[1])
+  ) {
+    const [, matchedChar] =
+      escapedCharacters.find((c) => c[0] === input[1]) ?? [];
+
     stack.push({
       parent: undefined,
       op: ops.match,
-      value: input[1],
+      value: matchedChar,
       node: undefined,
       nodes: undefined,
       left: undefined,

--- a/packages/nfa/lib/regexp.test.js
+++ b/packages/nfa/lib/regexp.test.js
@@ -244,19 +244,34 @@ describe("parse", () => {
     );
   });
 
-  it.only("should allow special characters", () => {
-    expect(parse("\\(")).toEqual(
-      node({
-        op: ops.sequence,
-        nodes: [
-          node({
-            op: ops.match,
-            value: "(",
-          }),
-        ],
-      })
-    );
-  });
+  it.each([
+    ["\\", "\\\\"],
+    ["(", "\\("],
+    [")", "\\)"],
+    [".", "\\."],
+    ["|", "\\|"],
+    ["*", "\\*"],
+    ["\n", "\\n"],
+    ["\r", "\\r"],
+    ["\t", "\\t"],
+    ["\b", "\\b"],
+    ["\f", "\\f"],
+  ])(
+    "should allow special character '%s' (escaped as '%s')",
+    (expected, input) => {
+      expect(parse(input)).toEqual(
+        node({
+          op: ops.sequence,
+          nodes: [
+            node({
+              op: ops.match,
+              value: expected,
+            }),
+          ],
+        })
+      );
+    }
+  );
 });
 
 describe("convertNode", () => {


### PR DESCRIPTION
This includes newlines, carriage returns, tabs and others.

Co-authored-by: Björn Brauer <zaubernerd@zaubernerd.de>
