### PR TITLE
perf: use node buffer test

### DIFF
--- a/packages/codegen/lib/javascript.js
+++ b/packages/codegen/lib/javascript.js
@@ -444,7 +444,7 @@ export class JavaScriptBaseCodegen {
         )}
         lexer.push('initial');
 
-        const stream = Buffer.from(input);
+        const stream = Buffer.isBuffer(input) ? input : Buffer.from(input);
 
         let result = nextToken(stream, 0);
         let lookahead = result.state;

--- a/parsers/json/generated/parser.js
+++ b/parsers/json/generated/parser.js
@@ -5558,7 +5558,7 @@ let nextToken;
 function parse(input) {
   lexer.push("initial");
 
-  const stream = Buffer.from(input);
+  const stream = Buffer.isBuffer(input) ? input : Buffer.from(input);
 
   let result = nextToken(stream, 0);
   let lookahead = result.state;


### PR DESCRIPTION
Instead of using Buffer.from in all cases, we use the given buffer
directly if possible.

Co-authored-by: Björn Brauer <zaubernerd@zaubernerd.de>
