### PR TITLE
perf: remove useless modulo check

### DIFF
--- a/packages/codegen/lib/javascript.js
+++ b/packages/codegen/lib/javascript.js
@@ -140,9 +140,7 @@ export class JavaScriptBaseCodegen {
         while (!success && n > 0) {
           ${(() => {
             return isOptimizable
-              ? `success = visited[n] <= ${
-                  finals[finals.length - 1]
-                } && visited[n] % ${columns} === 0;`
+              ? `success = visited[n] <= ${finals[finals.length - 1]};`
               : `success = ${finals
                   .map((final) => `${final} === visited[n]`)
                   .join(" || ")};`;

--- a/parsers/json/generated/lexer-initial.js
+++ b/parsers/json/generated/lexer-initial.js
@@ -1383,7 +1383,7 @@ const next = (input, offset) => {
   let success = false;
   let n = j;
   while (!success && n > 0) {
-    success = visited[n] <= 19712 && visited[n] % 256 === 0;
+    success = visited[n] <= 19712;
     n--;
   }
   n = n + 1;


### PR DESCRIPTION
All states are divisible by 256, therefore the modulo check will always
be 0.
We might need to adapt the `isOptimizable` check though, to make sure
that the finals are the first few states.
This gives me on my machine another 5ms (~234ms - ~229ms).
