### PR TITLE
fix: generate the json parser before running tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "preinstall": "npx only-allow pnpm",
     "check": "tsc --build .",
     "check-watch": "tsc --build . --watch",
+    "pretest": "pnpm run --dir parsers/json start",
     "test": "cross-env NODE_OPTIONS=--experimental-vm-modules jest --run-in-band"
   },
   "engines": {


### PR DESCRIPTION
This will regenerate the json parser upfront to the test execution.
With this change the test are always showing an up-to-date state.

Co-authored-by: Björn Brauer <zaubernerd@zaubernerd.de>
