### PR TITLE
test: add test case to compare different parsers

### DIFF
--- a/packages/codegen/lib/javascript.js
+++ b/packages/codegen/lib/javascript.js
@@ -84,6 +84,7 @@ export class JavaScriptBaseCodegen {
     }
 
     const code = `${this._lexerPreCode()}
+      // @ts-nocheck
 
       const EOF = "${EOF}";
       const ERROR = "${ERROR}";
@@ -235,7 +236,7 @@ export class JavaScriptBaseCodegen {
       Array.from(state.values()).some((item) => item.semanticAction)
     );
 
-    const code = `
+    const code = `// @ts-nocheck
       ${this._parserImports(lexerData)}
 
       /*

--- a/parsers/json/generated/lexer-initial.js
+++ b/parsers/json/generated/lexer-initial.js
@@ -1,3 +1,5 @@
+// @ts-nocheck
+
 const EOF = "@par-gen.EOF";
 const ERROR = "@par-gen.ERROR";
 

--- a/parsers/json/generated/parser.js
+++ b/parsers/json/generated/parser.js
@@ -1,3 +1,5 @@
+// @ts-nocheck
+
 import { next as nextTokenInitial } from "./lexer-initial.js";
 
 /*

--- a/parsers/json/package.json
+++ b/parsers/json/package.json
@@ -14,5 +14,15 @@
     "testPathIgnorePatterns": [
       "/node_modules/"
     ]
+  },
+  "devDependencies": {
+    "@babel/parser": "7.12.11",
+    "@jest/globals": "26.6.2",
+    "@types/json5": "0.0.30",
+    "@types/node": "14.14.16",
+    "acorn": "8.0.4",
+    "esbuild": "0.8.26",
+    "json5": "2.1.3",
+    "typescript": "4.1.3"
   }
 }

--- a/parsers/json/speed-test-execution.js
+++ b/parsers/json/speed-test-execution.js
@@ -1,0 +1,144 @@
+import { promises as fsp } from "fs";
+import { performance } from "perf_hooks";
+import { parse as acornParse } from "acorn";
+import { parse as babelParse } from "@babel/parser";
+// note: does not work on windows
+// import simdJsonParser from "simdjson";
+import ts from "typescript";
+// import esbuildParser from "esbuild";
+import json5Parser from "json5";
+
+import { parse as pargenParse } from "./generated/parser.js";
+
+/**
+ * @param {string} file
+ * @param {number} iterations
+ */
+async function run(file, iterations) {
+  /**
+   * @param {string} name
+   * @param {() => void} fn
+   * @returns {[string, number]}
+   */
+  const time = (name, fn) => {
+    const start = performance.now();
+    fn();
+    const end = performance.now();
+    return [name, end - start];
+  };
+
+  const warmup = 1_000;
+
+  const buffer = await fsp.readFile(file);
+  const string = buffer.toString();
+  const source = `var a = ${string};`;
+
+  // warm
+  for (let i = 0; i < warmup; i++) {
+    pargenParse(buffer);
+  }
+
+  const pargen = time("par-gen", () => {
+    for (let i = 0; i < iterations; i++) {
+      pargenParse(buffer);
+    }
+  });
+
+  // warm
+  // no warm-up required (native code)
+
+  const native = time("native", () => {
+    for (let i = 0; i < iterations; i++) {
+      JSON.parse(string);
+    }
+  });
+
+  // warm
+  for (let i = 0; i < warmup; i++) {
+    acornParse(source, { ecmaVersion: "latest" });
+  }
+
+  const acorn = time("acorn", () => {
+    for (let i = 0; i < iterations; i++) {
+      acornParse(source, { ecmaVersion: "latest" });
+    }
+  });
+
+  // warm
+  for (let i = 0; i < warmup; i++) {
+    babelParse(source);
+  }
+
+  const babel = time("babel", () => {
+    for (let i = 0; i < iterations; i++) {
+      babelParse(source);
+    }
+  });
+
+  // skip simdjson because it does not work on windows
+  // warm
+  // no warm-up required (native code)
+
+  // const simdJson = time("simdjson", () => {
+  //   for (let i = 0; i < iterations; i++) {
+  //     simdJsonParser.parse(string);
+  //   }
+  // });
+
+  // warm
+  for (let i = 0; i < warmup; i++) {
+    ts.parseJsonText("file", string);
+  }
+
+  const typescript = time("typescript", () => {
+    for (let i = 0; i < iterations; i++) {
+      ts.parseJsonText("file", string);
+    }
+  });
+
+  // skip esbuild because its too slow to parse just json
+  // warm
+  // no warm-up required (native code)
+
+  // const esbuild = time("esbuild", () => {
+  //   for (let i = 0; i < 1_000; i++) {
+  //     esbuildParser.transformSync(source, { loader: "js", minify: false });
+  //   }
+  // });
+
+  // warm
+  for (let i = 0; i < warmup; i++) {
+    json5Parser.parse(string);
+  }
+
+  const json5 = time("json5", () => {
+    for (let i = 0; i < iterations; i++) {
+      json5Parser.parse(string);
+    }
+  });
+
+  process.send?.({
+    command: "done",
+    body: {
+      pargen,
+      native,
+      acorn,
+      babel,
+      // simdJson,
+      typescript,
+      // esbuild,
+      json5,
+    },
+  });
+
+  process.exit(0);
+}
+
+process.on("message", async ({ command, body }) => {
+  if (command === "start") {
+    const { file, iterations } = body;
+    run(file, iterations);
+  }
+});
+
+process.send?.({ command: "ready" });

--- a/parsers/json/speed.test.js
+++ b/parsers/json/speed.test.js
@@ -1,0 +1,72 @@
+import { fork } from "child_process";
+import { fileURLToPath } from "url";
+import { dirname, resolve as pathResolve } from "path";
+import { jest } from "@jest/globals";
+
+const iterations = 10_000;
+
+/**
+ * @param {{[name: string]: [string, number]}} results
+ */
+const result = (results) => {
+  console.log(`
+Executing in a loop with ${iterations.toLocaleString()} iterations:
+${Object.values(results)
+  .map((result) => `  - Running ${result[0]} took ${result[1].toFixed(2)} ms`)
+  .join("\n")}
+  `);
+};
+
+jest.setTimeout(10_000);
+
+describe("JSON", () => {
+  it("should compare to others", async () => {
+    const results = await new Promise((resolve, reject) => {
+      try {
+        const child = fork("./speed-test-execution.js", {
+          cwd: dirname(fileURLToPath(import.meta.url)),
+          stdio: "inherit",
+        });
+
+        child.on(
+          "message",
+          /**
+           * @param {{command: string, body?: any}} event
+           */
+          (event) => {
+            if (event.command === "ready") {
+              child.send({
+                command: "start",
+                body: {
+                  file: pathResolve("package.json"),
+                  iterations,
+                },
+              });
+            } else if (event.command === "done") {
+              resolve(event.body);
+            }
+          }
+        );
+
+        child.on("exit", (code) => {
+          if (code !== 0) {
+            reject(code);
+          }
+        });
+      } catch (e) {
+        reject(e);
+      }
+    });
+
+    result(results);
+
+    // expect pargen to run three times slower to native (for now)
+    expect(results.pargen[1]).toBeLessThanOrEqual(results.native[1] * 3);
+    expect(results.pargen[1]).toBeLessThanOrEqual(results.acorn[1]);
+    expect(results.pargen[1]).toBeLessThanOrEqual(results.babel[1]);
+    // expect(results.pargen[1]).toBeLessThanOrEqual(results.simdJson[1]);
+    expect(results.pargen[1]).toBeLessThanOrEqual(results.typescript[1]);
+    // expect(results.pargen[1]).toBeLessThanOrEqual(results.esbuild[1]);
+    expect(results.pargen[1]).toBeLessThanOrEqual(results.json5[1]);
+  });
+});

--- a/parsers/json/tsconfig.json
+++ b/parsers/json/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "rootDir": ".",
+    "composite": true,
+    "noEmit": true,
+    "emitDeclarationOnly": false
+  },
+  "include": ["."],
+  "exclude": ["**/node_modules/**"],
+  "references": [
+    {
+      "path": "../../packages/cli"
+    }
+  ]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -95,8 +95,25 @@ importers:
   parsers/json:
     dependencies:
       '@par-gen/cli': 'link:../../packages/cli'
+    devDependencies:
+      '@babel/parser': 7.12.11
+      '@jest/globals': 26.6.2
+      '@types/json5': 0.0.30
+      '@types/node': 14.14.16
+      acorn: 8.0.4
+      esbuild: 0.8.26
+      json5: 2.1.3
+      typescript: 4.1.3
     specifiers:
+      '@babel/parser': 7.12.11
+      '@jest/globals': 26.6.2
       '@par-gen/cli': 'workspace:0.1.0'
+      '@types/json5': 0.0.30
+      '@types/node': 14.14.16
+      acorn: 8.0.4
+      esbuild: 0.8.26
+      json5: 2.1.3
+      typescript: 4.1.3
 lockfileVersion: 5.2
 packages:
   /@babel/code-frame/7.12.11:
@@ -676,6 +693,10 @@ packages:
     dev: true
     resolution:
       integrity: sha512-jqHoirTG61fee6v6rwbnEuKhpSKih0tuhqeFbCmMmErhtu3BYlOZaXWjffgOstMM4S/3iQD31lI5bGLTrs97yQ==
+  /@types/json5/0.0.30:
+    dev: true
+    resolution:
+      integrity: sha512-sqm9g7mHlPY/43fcSNrCYfOeX9zkTTK+euO5E6+CVijSMm5tTjkVdwdqRkY3ljjIAf8679vps5jKUoJBCLsMDA==
   /@types/mri/1.1.0:
     dev: true
     resolution:
@@ -744,6 +765,13 @@ packages:
     hasBin: true
     resolution:
       integrity: sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A==
+  /acorn/8.0.4:
+    dev: true
+    engines:
+      node: '>=0.4.0'
+    hasBin: true
+    resolution:
+      integrity: sha512-XNP0PqF1XD19ZlLKvB7cMmnZswW4C/03pRHgirB30uSJTaS3A3V1/P4sS3HPvFmjoriPCJQs+JDSbm4bL1TxGQ==
   /ajv/6.12.6:
     dependencies:
       fast-deep-equal: 3.1.3
@@ -1400,6 +1428,12 @@ packages:
     dev: true
     resolution:
       integrity: sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==
+  /esbuild/0.8.26:
+    dev: true
+    hasBin: true
+    requiresBuild: true
+    resolution:
+      integrity: sha512-u3MMHOOumdWoAKF+073GHPpzvVB2cM+y9VD4ZwYs1FAQ6atRPISya35dbrbOu/mM68mQ42P+nwPzQVBTfQhkvQ==
   /escape-string-regexp/1.0.5:
     dev: true
     engines:

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -44,6 +44,9 @@
     },
     {
       "path": "packages/parser"
+    },
+    {
+      "path": "parsers/json"
     }
   ]
 }


### PR DESCRIPTION
To remove the jest overhead and see the correct result we run the speed
test in a forked node process.

Co-authored-by: Björn Brauer <zaubernerd@zaubernerd.de>
