### PR TITLE
test: run slow tests only on demand

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,4 +35,6 @@ jobs:
 
       - run: npm ci
       - run: npm run check
-      - run: npm test
+      - run: npm test -- --run-in-band
+        env:
+          RUN_SLOW_TESTS: 1

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   "scripts": {
     "check": "tsc --build .",
     "check-watch": "tsc --build . --watch",
-    "test": "cross-env NODE_OPTIONS=--experimental-vm-modules jest --run-in-band"
+    "test": "cross-env NODE_OPTIONS=--experimental-vm-modules jest"
   },
   "engines": {
     "node": ">=14",

--- a/packages/dfa/lib/dfa.test.js
+++ b/packages/dfa/lib/dfa.test.js
@@ -1,4 +1,3 @@
-import { performance } from "perf_hooks";
 import { NFA } from "@par-gen/nfa";
 
 import { DFA } from "./dfa.js";
@@ -178,62 +177,6 @@ describe("DFA", () => {
         .compile((symbol) => symbol.charCodeAt(0));
 
       expect(compiled(Buffer.from("abcffghmnijmn"))).toBe(true);
-    });
-
-    it("should be fast", () => {
-      /**
-       * @param {string} name
-       * @param {() => void} fn
-       * @returns {[string, number]}
-       */
-      const time = (name, fn) => {
-        const start = performance.now();
-        fn();
-        const end = performance.now();
-        return [name, end - start];
-      };
-
-      const compiled = DFA.fromNFA(
-        NFA.fromRegExp("ab(c|d)(e|f)*((gh|ij)(kl|mn))*")
-      )
-        .minimal()
-        .compile((symbol) => symbol.charCodeAt(0));
-
-      const string = "abcffghmnijmn";
-      const input = Buffer.from(string);
-      const iterations = 50_000_000;
-
-      // make the function hot
-      for (let i = 0; i < 1_000; i++) {
-        compiled(input);
-      }
-
-      const dfaResult = time("dfa", () => {
-        for (let i = 0; i < iterations; i++) {
-          compiled(input);
-        }
-      });
-
-      const regexp = new RegExp("ab(?:c|d)(?:e|f)*(?:(?:gh|ij)(?:kl|mn))*");
-      // make the expr hot
-      for (let i = 0; i < 1_000; i++) {
-        regexp.test(string);
-      }
-
-      const nativeResult = time("native", () => {
-        for (let i = 0; i < iterations; i++) {
-          // string.match(regexp);
-          regexp.test(string);
-        }
-      });
-
-      console.log(`
-Executing in a loop with ${iterations.toLocaleString()} iterations:
-- Running ${dfaResult[0]} took ${dfaResult[1].toFixed(2)} ms
-- Running ${nativeResult[0]} took ${nativeResult[1].toFixed(2)} ms
-`);
-
-      expect(dfaResult[1]).toBeLessThanOrEqual(nativeResult[1]);
     });
   });
 });

--- a/packages/dfa/lib/speed.test.js
+++ b/packages/dfa/lib/speed.test.js
@@ -1,0 +1,71 @@
+import { performance } from "perf_hooks";
+import { NFA } from "@par-gen/nfa";
+
+import { DFA } from "./dfa.js";
+
+/**
+ * @template T
+ * @typedef {import('@par-gen/nfa/types/regexp').ParseTree<T>} ParseTree
+ */
+
+if (process.env.RUN_SLOW_TESTS) {
+  describe("DFA compile", () => {
+    it("should be fast", () => {
+      /**
+       * @param {string} name
+       * @param {() => void} fn
+       * @returns {[string, number]}
+       */
+      const time = (name, fn) => {
+        const start = performance.now();
+        fn();
+        const end = performance.now();
+        return [name, end - start];
+      };
+
+      const compiled = DFA.fromNFA(
+        NFA.fromRegExp("ab(c|d)(e|f)*((gh|ij)(kl|mn))*")
+      )
+        .minimal()
+        .compile((symbol) => symbol.charCodeAt(0));
+
+      const string = "abcffghmnijmn";
+      const input = Buffer.from(string);
+      const iterations = 50_000_000;
+
+      // make the function hot
+      for (let i = 0; i < 1_000; i++) {
+        compiled(input);
+      }
+
+      const dfaResult = time("dfa", () => {
+        for (let i = 0; i < iterations; i++) {
+          compiled(input);
+        }
+      });
+
+      const regexp = new RegExp("ab(?:c|d)(?:e|f)*(?:(?:gh|ij)(?:kl|mn))*");
+      // make the expr hot
+      for (let i = 0; i < 1_000; i++) {
+        regexp.test(string);
+      }
+
+      const nativeResult = time("native", () => {
+        for (let i = 0; i < iterations; i++) {
+          // string.match(regexp);
+          regexp.test(string);
+        }
+      });
+
+      console.log(`
+  Executing in a loop with ${iterations.toLocaleString()} iterations:
+  - Running ${dfaResult[0]} took ${dfaResult[1].toFixed(2)} ms
+  - Running ${nativeResult[0]} took ${nativeResult[1].toFixed(2)} ms
+  `);
+
+      expect(dfaResult[1]).toBeLessThanOrEqual(nativeResult[1]);
+    });
+  });
+} else {
+  test.skip("Skipped speed test", () => undefined);
+}

--- a/parsers/json/speed.test.js
+++ b/parsers/json/speed.test.js
@@ -19,54 +19,58 @@ ${Object.values(results)
 
 jest.setTimeout(10_000);
 
-describe("JSON", () => {
-  it("should compare to others", async () => {
-    const results = await new Promise((resolve, reject) => {
-      try {
-        const child = fork("./speed-test-execution.js", {
-          cwd: dirname(fileURLToPath(import.meta.url)),
-          stdio: "inherit",
-        });
+if (process.env.RUN_SLOW_TESTS) {
+  describe("JSON", () => {
+    it("should compare to others", async () => {
+      const results = await new Promise((resolve, reject) => {
+        try {
+          const child = fork("./speed-test-execution.js", {
+            cwd: dirname(fileURLToPath(import.meta.url)),
+            stdio: "inherit",
+          });
 
-        child.on(
-          "message",
-          /**
-           * @param {{command: string, body?: any}} event
-           */
-          (event) => {
-            if (event.command === "ready") {
-              child.send({
-                command: "start",
-                body: {
-                  file: pathResolve("package.json"),
-                  iterations,
-                },
-              });
-            } else if (event.command === "done") {
-              resolve(event.body);
+          child.on(
+            "message",
+            /**
+             * @param {{command: string, body?: any}} event
+             */
+            (event) => {
+              if (event.command === "ready") {
+                child.send({
+                  command: "start",
+                  body: {
+                    file: pathResolve("package.json"),
+                    iterations,
+                  },
+                });
+              } else if (event.command === "done") {
+                resolve(event.body);
+              }
             }
-          }
-        );
+          );
 
-        child.on("exit", (code) => {
-          if (code !== 0) {
-            reject(code);
-          }
-        });
-      } catch (e) {
-        reject(e);
-      }
+          child.on("exit", (code) => {
+            if (code !== 0) {
+              reject(code);
+            }
+          });
+        } catch (e) {
+          reject(e);
+        }
+      });
+
+      result(results);
+
+      // expect pargen to run three times slower to native (for now)
+      expect(results.pargen[1]).toBeLessThanOrEqual(results.native[1] * 3);
+      expect(results.pargen[1]).toBeLessThanOrEqual(results.acorn[1]);
+      expect(results.pargen[1]).toBeLessThanOrEqual(results.babel[1]);
+      // expect(results.pargen[1]).toBeLessThanOrEqual(results.simdJson[1]);
+      expect(results.pargen[1]).toBeLessThanOrEqual(results.typescript[1]);
+      // expect(results.pargen[1]).toBeLessThanOrEqual(results.esbuild[1]);
+      expect(results.pargen[1]).toBeLessThanOrEqual(results.json5[1]);
     });
-
-    result(results);
-
-    // expect pargen to run three times slower to native (for now)
-    expect(results.pargen[1]).toBeLessThanOrEqual(results.native[1] * 3);
-    expect(results.pargen[1]).toBeLessThanOrEqual(results.acorn[1]);
-    expect(results.pargen[1]).toBeLessThanOrEqual(results.babel[1]);
-    // expect(results.pargen[1]).toBeLessThanOrEqual(results.simdJson[1]);
-    expect(results.pargen[1]).toBeLessThanOrEqual(results.typescript[1]);
-    // expect(results.pargen[1]).toBeLessThanOrEqual(results.esbuild[1]);
-    expect(results.pargen[1]).toBeLessThanOrEqual(results.json5[1]);
   });
-});
+} else {
+  test.skip("Skipped speed test", () => undefined);
+}


### PR DESCRIPTION
This change will skip over the slower tests (e.g. benchmarks) by
default.
On the CI all tests are executed and run in band, while locally all fast
tests are executed in parallel.
